### PR TITLE
fix: ALAC ffprobe bitrate parsing

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -3850,9 +3850,15 @@ func TestParseALACInfo(t *testing.T) {
 			hasError: false,
 		},
 		{
-			name:     "Multiple streams - takes first",
+			name:     "Multiple streams - takes first valid audio stream",
 			input:    "48000,24\n96000,16\n",
 			expected: &AudioInfo{Bits: 24, Rate: 48000, Format: "alac"},
+			hasError: false,
+		},
+		{
+			name:     "Audio stream with cover art - like real ALAC file",
+			input:    "88200,24\n8\n",
+			expected: &AudioInfo{Bits: 24, Rate: 88200, Format: "alac"},
 			hasError: false,
 		},
 		{


### PR DESCRIPTION
This PR fixes the ALAC bitrate parsing issue, so ALAC should be identified properly now.

Fixes #15 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use ffprobe `bits_per_raw_sample` and parse first valid audio stream, skipping invalid/cover-art lines; update tests accordingly.
> 
> - **ALAC parsing**:
>   - Switch ffprobe field from `bits_per_sample` to `bits_per_raw_sample` in `getALACInfo` (both Docker and local).
>   - Make `parseALACInfo` robust: iterate lines, validate rate/bit depth, enforce reasonable sample-rate bounds, and return the first valid audio stream; error if none.
> - **Tests**:
>   - Update test to expect first valid audio stream among multiple lines.
>   - Add case simulating cover art line following a valid audio stream.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4ebdb317b0abe80a85b06a5ef7d4f26032b33e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->